### PR TITLE
Allowable blockBreakEvent for Treecapitator

### DIFF
--- a/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/mana/ManaAbilityBlockBreakEvent.java
+++ b/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/mana/ManaAbilityBlockBreakEvent.java
@@ -5,9 +5,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class TerraformBlockBreakEvent extends BlockBreakEvent {
+public class ManaAbilityBlockBreakEvent extends BlockBreakEvent {
 
-    public TerraformBlockBreakEvent(@NotNull Block theBlock, @NotNull Player player) {
+    public ManaAbilityBlockBreakEvent(@NotNull Block theBlock, @NotNull Player player) {
         super(theBlock, player);
     }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
@@ -1,6 +1,6 @@
 package dev.aurelium.auraskills.bukkit.skills.excavation;
 
-import dev.aurelium.auraskills.api.event.mana.TerraformBlockBreakEvent;
+import dev.aurelium.auraskills.api.event.mana.ManaAbilityBlockBreakEvent;
 import dev.aurelium.auraskills.api.mana.ManaAbilities;
 import dev.aurelium.auraskills.api.source.XpSource;
 import dev.aurelium.auraskills.api.source.type.BlockXpSource;
@@ -112,7 +112,7 @@ public class Terraform extends ReadiedManaAbility {
             block.removeMetadata("AureliumSkills-Terraform", plugin);
             return;
         }
-        TerraformBlockBreakEvent event = new TerraformBlockBreakEvent(block, player);
+        ManaAbilityBlockBreakEvent event = new ManaAbilityBlockBreakEvent(block, player);
         Bukkit.getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
             block.breakNaturally(player.getInventory().getItemInMainHand());

--- a/common/src/main/resources/mana_abilities.yml
+++ b/common/src/main/resources/mana_abilities.yml
@@ -32,6 +32,7 @@ mana_abilities:
     sneak_offhand_bypass: true
     max_blocks_multiplier: 1
     give_xp: true
+    use_events: false
   auraskills/speed_mine:
     enabled: true
     base_value: 10.0
@@ -118,4 +119,4 @@ mana_abilities:
     require_sneak: false
     check_offhand: true
     sneak_offhand_bypass: true
-file_version: 3
+file_version: 4


### PR DESCRIPTION
Blocks broken by treecapitator don't fire the blockBreakEvent, this can now be enabled in the mana_abilities.yml config. When enabled plugins like CoreProtect can detect all broken blocks.