### PR TITLE
Configurable mana ability item durability

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
@@ -93,8 +93,13 @@ public class Terraform extends ReadiedManaAbility {
         BlockFace[] faces = new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
         LinkedList<Block> toCheck = new LinkedList<>();
         toCheck.add(block);
+
         int count = 0;
         int maxCount = manaAbility.optionInt("max_blocks", 61);
+        if (manaAbility.optionBoolean("max_limit_durability", false)) {
+            maxCount = getHoldingMaterialDurability(player, maxCount);
+        }
+
         while ((block = toCheck.poll()) != null && count < maxCount) {
             if (block.getType() == material) {
                 block.setMetadata("AureliumSkills-Terraform", new FixedMetadataValue(plugin, true));
@@ -105,6 +110,8 @@ public class Terraform extends ReadiedManaAbility {
                 count++;
             }
         }
+
+        setHoldingMaterialDurability(player, count, manaAbility.optionDouble("durability_multiplier", 0));
     }
 
     private void breakBlock(Player player, Block block) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Treecapitator extends ReadiedManaAbility {
 
@@ -90,21 +91,36 @@ public class Treecapitator extends ReadiedManaAbility {
             User user = plugin.getUser(player);
 
             if (isActivated(user)) {
-                breakTree(user, block, source);
+                breakTree(player, user, block, source);
                 return;
             }
             if (isHoldingMaterial(player) && checkActivation(player)) {
-                breakTree(user, block, source);
+                breakTree(player, user, block, source);
             }
         }
     }
 
-    public void breakTree(User user, Block block, BlockXpSource source) {
-        breakBlock(user, block, new TreecapitatorTree(block, source));
+    public void breakTree(Player player, User user, Block block, BlockXpSource source) {
+        AtomicInteger taskCount = new AtomicInteger(1);
+        TreecapitatorTree tree = new TreecapitatorTree(block, source);
+        double multiplier = manaAbility.optionDouble("durability_multiplier", 0);
+
+        // Make sure the max blocks does not exceed the durability, when applicable.
+        if (manaAbility.optionBoolean("max_limit_durability", false)) {
+            tree.setMaxBlocks(getHoldingMaterialDurability(player, tree.getMaxBlocks()));
+        }
+
+        breakBlock(player, user, block, tree, taskCount, () -> {
+            taskCount.decrementAndGet();
+            if (taskCount.get() == 0) {
+                setHoldingMaterialDurability(player, tree.getBlocksBroken(), multiplier);
+            }
+        });
     }
 
-    private void breakBlock(User user, Block block, TreecapitatorTree tree) {
+    private void breakBlock(Player player, User user, Block block, TreecapitatorTree tree, AtomicInteger taskCount, Runnable onComplete) {
         if (tree.getBlocksBroken() > tree.getMaxBlocks()) {
+            onComplete.run();
             return;
         }
         for (Block adjacentBlock : BlockFaceUtil.getSurroundingBlocks(block)) {
@@ -123,11 +139,15 @@ public class Treecapitator extends ReadiedManaAbility {
             // Continue breaking blocks
             Block originalBlock = tree.getOriginalBlock();
             if (adjacentBlock.getX() > originalBlock.getX() + 6 || adjacentBlock.getZ() > originalBlock.getZ() + 6 || adjacentBlock.getY() > originalBlock.getY() + 31) {
+                onComplete.run();
                 return;
             }
             // Break the next blocks
-            plugin.getScheduler().scheduleSync(() -> breakBlock(user, adjacentBlock, tree), 50, TimeUnit.MILLISECONDS);
+            taskCount.incrementAndGet();
+            plugin.getScheduler().scheduleSync(() -> breakBlock(player, user, adjacentBlock, tree, taskCount, onComplete), 50, TimeUnit.MILLISECONDS);
         }
+
+        onComplete.run();
     }
 
     @Nullable
@@ -183,6 +203,10 @@ public class Treecapitator extends ReadiedManaAbility {
 
         public int getMaxBlocks() {
             return maxBlocks;
+        }
+
+        public void setMaxBlocks(int maxBlocks) {
+            this.maxBlocks = maxBlocks;
         }
 
         private void setMaxBlocks(BlockXpSource source) {

--- a/common/src/main/resources/mana_abilities.yml
+++ b/common/src/main/resources/mana_abilities.yml
@@ -32,6 +32,9 @@ mana_abilities:
     sneak_offhand_bypass: true
     max_blocks_multiplier: 1
     give_xp: true
+    use_events: false
+    durability_multiplier: 0
+    max_limit_durability: false
   auraskills/speed_mine:
     enabled: true
     base_value: 10.0
@@ -76,6 +79,8 @@ mana_abilities:
     check_offhand: true
     sneak_offhand_bypass: true
     max_blocks: 61
+    durability_multiplier: 0
+    max_limit_durability: false
   auraskills/charged_shot:
     enabled: true
     base_value: 0.5
@@ -118,4 +123,4 @@ mana_abilities:
     require_sneak: false
     check_offhand: true
     sneak_offhand_bypass: true
-file_version: 3
+file_version: 4


### PR DESCRIPTION
When configured set the item durability when using mana abilities like Terraform and Treecapitator.

Includes the option to break items when they've reached (or go over) the max damage value. With the option for durability as max_blocks limiter This allows tools with less remaining durability to break more blocks as they're able to if the max_blocks is higher.