### PR TITLE
Added XP Limiter

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
@@ -24,6 +24,7 @@ import dev.aurelium.auraskills.bukkit.item.*;
 import dev.aurelium.auraskills.bukkit.jobs.JobsListener;
 import dev.aurelium.auraskills.bukkit.leaderboard.BukkitLeaderboardExclusion;
 import dev.aurelium.auraskills.bukkit.level.BukkitLevelManager;
+import dev.aurelium.auraskills.bukkit.level.XpLimiter;
 import dev.aurelium.auraskills.bukkit.listeners.CriticalHandler;
 import dev.aurelium.auraskills.bukkit.listeners.DamageListener;
 import dev.aurelium.auraskills.bukkit.listeners.PlayerDeath;
@@ -454,6 +455,7 @@ public class AuraSkills extends JavaPlugin implements AuraSkillsPlugin {
         pm.registerEvents(new RegionBlockListener(this), this);
         pm.registerEvents(new PlayerDeath(this), this);
         pm.registerEvents(new JobsListener(this), this);
+        pm.registerEvents(new XpLimiter(this), this);
         pm.registerEvents(((BukkitLeaderboardExclusion) leaderboardManager.getLeaderboardExclusion()), this);
     }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/XpLimiter.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/XpLimiter.java
@@ -1,0 +1,109 @@
+package dev.aurelium.auraskills.bukkit.level;
+
+import dev.aurelium.auraskills.api.event.skill.XpGainEvent;
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.common.config.Option;
+import dev.aurelium.auraskills.common.message.type.LevelerMessage;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class XpLimiter implements Listener {
+
+    private final AuraSkills plugin;
+    private final Map<UUID, Map<String, XpLimiterRecord>> tracker = new HashMap<>();
+
+    public XpLimiter(AuraSkills plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onSkillXpGain(XpGainEvent event) {
+        if (!plugin.configBoolean(Option.LEVELER_LIMITER_ENABLED)) return;
+
+        String limitKey = "GLOBAL";
+        int limitCap = plugin.configInt(Option.LEVELER_LIMITER_GLOBAL_CAP);
+        int limitTime = plugin.configInt(Option.LEVELER_LIMITER_GLOBAL_TIME);
+
+        boolean enabled = true;
+
+        if (plugin.configBoolean(Option.LEVELER_LIMITER_PER_SKILL)) {
+            Skill skill = event.getSkill();
+            limitKey = skill.name().toUpperCase();
+            Map<String, Object> skillLimit = skill.optionMap("limiter");
+
+            if (skillLimit != null && !skillLimit.isEmpty()) {
+                enabled = (boolean) skillLimit.getOrDefault("enabled", enabled);
+                int skillCap = (int) skillLimit.getOrDefault("cap", limitCap);
+                int skillTime = (int) skillLimit.getOrDefault("time", limitTime);
+
+                if (skillCap > 0) limitCap = skillCap;
+                if (skillTime > 0) limitTime = skillTime;
+            }
+
+            if (!enabled) return;
+        }
+
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        long now = System.currentTimeMillis();
+
+        Map<String, XpLimiterRecord> xpTracker = tracker.get(uuid);
+        // Return if new tracker for player.
+        if (xpTracker == null) {
+            Map<String, XpLimiterRecord> newXpRecord = new HashMap<>();
+            putSkillRecord(uuid, limitKey, newXpRecord, event.getAmount(), now);
+            return;
+        }
+
+        XpLimiterRecord skillRecord = xpTracker.get(limitKey);
+        // Return if new skill for player.
+        if (skillRecord == null) {
+            putSkillRecord(uuid, limitKey, xpTracker, event.getAmount(), now);
+            return;
+        }
+
+        // Reset if expired.
+        long remainingTime = limitTime - ((now - skillRecord.timestamp()) / 1000);
+        if (remainingTime <= 0) {
+            putSkillRecord(uuid, limitKey, xpTracker, event.getAmount(), now);
+            return;
+        }
+
+        // Cancel (or max it) if going over cap.
+        double totalXp = skillRecord.xp() + event.getAmount();
+        if (totalXp > limitCap) {
+            // Either reward partially (if enabled) or cancel.
+            double remainingXp = limitCap - skillRecord.xp();
+            if (remainingXp > 0 && plugin.configBoolean(Option.LEVELER_LIMITER_PARTIAL_XP_GAIN)) {
+                event.setAmount(remainingXp);
+                putSkillRecord(uuid, limitKey, xpTracker, limitCap, now);
+                return;
+            } else {
+                trySendMessage(player, event, remainingTime);
+                event.setCancelled(true);
+                return;
+            }
+        }
+
+        // Update recorded with total received XP.
+        putSkillRecord(uuid, limitKey, xpTracker, totalXp, skillRecord.timestamp());
+    }
+
+    protected void putSkillRecord(UUID uuid, String key, Map<String, XpLimiterRecord> xpTracker, double cap, long now) {
+        xpTracker.put(key, new XpLimiterRecord(cap, now));
+        tracker.put(uuid, xpTracker);
+    }
+
+    protected void trySendMessage(Player player, XpGainEvent event, long remainingTime) {
+        plugin.getAbilityManager().sendMessage(player, plugin.getMsg(LevelerMessage.LIMIT_REACHED, event.getUser().getLocale()).replace("{time}",
+                String.valueOf(remainingTime)));
+    }
+
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/XpLimiterRecord.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/XpLimiterRecord.java
@@ -1,0 +1,4 @@
+package dev.aurelium.auraskills.bukkit.level;
+
+public record XpLimiterRecord(double xp, long timestamp) {
+}

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
@@ -114,6 +114,12 @@ public enum Option {
     AUTO_SAVE_ENABLED("auto_save.enabled", OptionType.BOOLEAN),
     AUTO_SAVE_INTERVAL_TICKS("auto_save.interval_ticks", OptionType.INT),
     // Leveler options
+    LEVELER_LIMITER_ENABLED("leveler.limiter.enabled", OptionType.BOOLEAN),
+    LEVELER_LIMITER_PER_SKILL("leveler.limiter.per_skill", OptionType.BOOLEAN),
+    LEVELER_LIMITER_PARTIAL_XP_GAIN("leveler.limiter.partial_xp_gain", OptionType.BOOLEAN),
+    LEVELER_LIMITER_NOTIFY_PLAYER("leveler.limiter.notify_player", OptionType.BOOLEAN),
+    LEVELER_LIMITER_GLOBAL_CAP("leveler.limiter.global.cap", OptionType.INT),
+    LEVELER_LIMITER_GLOBAL_TIME("leveler.limiter.global.time", OptionType.INT),
     LEVELER_TITLE_ENABLED("leveler.title.enabled", OptionType.BOOLEAN),
     LEVELER_TITLE_FADE_IN("leveler.title.fade_in", OptionType.INT),
     LEVELER_TITLE_STAY("leveler.title.stay", OptionType.INT),

--- a/common/src/main/java/dev/aurelium/auraskills/common/message/type/LevelerMessage.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/message/type/LevelerMessage.java
@@ -13,7 +13,8 @@ public enum LevelerMessage implements MessageKey {
     ABILITY_LEVEL_UP,
     MANA_ABILITY_UNLOCK,
     MANA_ABILITY_LEVEL_UP,
-    UNCLAIMED_ITEM;
+    UNCLAIMED_ITEM,
+    LIMIT_REACHED;
 
     @Override
     public String getPath() {

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -196,6 +196,14 @@ auto_save:
   enabled: true
   interval_ticks: 12000
 leveler:
+  limiter:
+    enabled: false
+    notify_player: true
+    partial_xp_gain: true
+    per_skill: true
+    global:
+      cap: 5000
+      time: 60
   title:
     enabled: true
     fade_in: 5

--- a/common/src/main/resources/messages/messages_cs.yml
+++ b/common/src/main/resources/messages/messages_cs.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Mana Ability Odemčený
   mana_ability_level_up: Mana Ability Level Up
   unclaimed_item: "<red>Máš nevyzvednuté položky, protože tvůj inventář byl plný, použij <yellow>/skills claimitems <red>pro vyzvednuti"
+  limit_reached: "<red>Limit dosažen, zbývá {time} sekund"
 menus:
   common:
     close: "Zavřít"

--- a/common/src/main/resources/messages/messages_de.yml
+++ b/common/src/main/resources/messages/messages_de.yml
@@ -682,6 +682,7 @@ leveler:
   mana_ability_unlock: Manafähigkeit freigeschaltet
   mana_ability_level_up: Manafähigkeiten Levelaufstieg
   unclaimed_item: "<red>Du hast unbeanspruchte Gegenstände, weil dein Inventar voll war, benutze <yellow>/Skills um <red>to sie zu beanspruchen"
+  limit_reached: "<red>Limit erreicht, noch {time} Sekunden übrig"
 menus:
   common:
     close: "Schließen"

--- a/common/src/main/resources/messages/messages_en.yml
+++ b/common/src/main/resources/messages/messages_en.yml
@@ -684,6 +684,7 @@ leveler:
   mana_ability_unlock: Mana Ability Unlock
   mana_ability_level_up: Mana Ability Level Up
   unclaimed_item: "<red>You have unclaimed items because your inventory was full, use <yellow>/skills claimitems <red>to claim them"
+  limit_reached: "<red>Limit reached, {time} seconds remaining"
 menus:
   common:
     close: "Close"

--- a/common/src/main/resources/messages/messages_es.yml
+++ b/common/src/main/resources/messages/messages_es.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Habilidad de Maná Desbloqueada
   mana_ability_level_up: Nuevo Nivel de Habilidad de Maná
   unclaimed_item: "<red>Tienes objetos sin reclamar porque tu invnetario estaba lleno, usa <yellow>/skills claimitems <red>para reclamarlos"
+  limit_reached: "<red>Límite alcanzado, quedan {time} segundos"
 menus:
   common:
     close: "Cerrar"

--- a/common/src/main/resources/messages/messages_fi.yml
+++ b/common/src/main/resources/messages/messages_fi.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Mana-kyky avattu
   mana_ability_level_up: Mana-kyvyn taso nousi
   unclaimed_item: "<red>Sinulla on lunastamattomia kohteita, koska varastosi oli täynnä. Käytä <yellow> /skills claimitems lunastaaksesi ne <red>"
+  limit_reached: "<red>Raja saavutettu, {time} sekuntia jäljellä"
 menus:
   common:
     close: "Sulje"

--- a/common/src/main/resources/messages/messages_fr.yml
+++ b/common/src/main/resources/messages/messages_fr.yml
@@ -566,6 +566,7 @@ leveler:
   mana_ability_unlock: Capacité de mana débloquée
   mana_ability_level_up: Niveau de compétence de mana supérieur
   unclaimed_item: "<red>Vous avez des objets non réclamés parce que votre inventaire était plein, utilisez <yellow>/skills claimitems <red>pour les réclamer"
+  limit_reached: "<red>Limite atteinte, il reste {time} secondes"
 menus:
   common:
     close: "Fermer"

--- a/common/src/main/resources/messages/messages_id.yml
+++ b/common/src/main/resources/messages/messages_id.yml
@@ -566,6 +566,7 @@ leveler:
   mana_ability_unlock: Kemampuan Mana Terbuka
   mana_ability_level_up: Kemampuan Mana Naik Level
   unclaimed_item: "<red>Anda memiliki item yang belum diklaim karena inventaris Anda penuh, gunakan <yellow>/skills claimitems <red>untuk mengklaimnya"
+  limit_reached: "<red>Batas tercapai, tersisa {time} detik"
 menus:
   common:
     close: "Tutup"

--- a/common/src/main/resources/messages/messages_it.yml
+++ b/common/src/main/resources/messages/messages_it.yml
@@ -566,6 +566,7 @@ leveler:
   mana_ability_unlock: Abilità Mana Sbloccata
   mana_ability_level_up: Abilità Mana Level Up
   unclaimed_item: "<red>Hai oggetti non reclamati perchè il tuo inventario era pieno, usa <yellow>/skills claimitems <red>per reclamarli"
+  limit_reached: "<red>Limite raggiunto, restano {time} secondi"
 menus:
   common:
     close: "Chiudi"

--- a/common/src/main/resources/messages/messages_ja.yml
+++ b/common/src/main/resources/messages/messages_ja.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: マナアビリティーアンロック
   mana_ability_level_up: マナアビリティーアンロック
   unclaimed_item: "<red>インベントリがいっぱいのため、受け取っていないアイテムがあります。 <yellow>/skills claimitems <red>で受け取る"
+  limit_reached: "<red>上限に達しました、残り{time}秒です"
 menus:
   common:
     close: "閉じる"

--- a/common/src/main/resources/messages/messages_ko.yml
+++ b/common/src/main/resources/messages/messages_ko.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: 마나 능력 잠금 해제
   mana_ability_level_up: 마나 능력 레벨 업
   unclaimed_item: "<red>인벤토리가 가득 차서 수령하지 않은 아이템이 있습니다. <yellow>/skillsclaimitems<red>를 사용하여 수령하세요."
+  limit_reached: "<red>제한에 도달했습니다. {time}초 남았습니다"
 menus:
   common:
     close: "닫기"

--- a/common/src/main/resources/messages/messages_nl.yml
+++ b/common/src/main/resources/messages/messages_nl.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Mana Ability Unlock
   mana_ability_level_up: Mana Ability Level Up
   unclaimed_item: "<red>You have unclaimed items because your inventory was full, use <yellow>/skills claimitems <red>to claim them"
+  limit_reached: "<red>Limiet bereikt, nog {time} seconden"
 menus:
   common:
     close: "Close"

--- a/common/src/main/resources/messages/messages_pl.yml
+++ b/common/src/main/resources/messages/messages_pl.yml
@@ -682,6 +682,7 @@ leveler:
   mana_ability_unlock: Odblokowano Zdolność Many
   mana_ability_level_up: Nowy Poziom Zdolności Many
   unclaimed_item: "<red>Masz nieodebrane przedmioty, ponieważ twój ekwipunek był pełny, użyj <yellow>/skills claimitems <red>aby je odebrać"
+  limit_reached: "<red>Osiągnięto limit, pozostało {time} sekund"
 menus:
   common:
     close: "Zamknij"

--- a/common/src/main/resources/messages/messages_pt-BR.yml
+++ b/common/src/main/resources/messages/messages_pt-BR.yml
@@ -566,6 +566,7 @@ leveler:
   mana_ability_unlock: Habilidades de Mana desbloqueadas
   mana_ability_level_up: Habilidade de Mana Melhorada
   unclaimed_item: "<red>Você tem itens não resgatados porque o seu inventário estava cheio, use <yellow>/skills claimitems <red>para reivindicar eles"
+  limit_reached: "<red>Limite atingido, restam {time} segundos"
 menus:
   common:
     close: "Fechar"

--- a/common/src/main/resources/messages/messages_ru.yml
+++ b/common/src/main/resources/messages/messages_ru.yml
@@ -566,6 +566,7 @@ leveler:
   mana_ability_unlock: Мана способность разблокирована
   mana_ability_level_up: Уровень мана способности повышен
   unclaimed_item: "<red>У вас есть не собранные предметы, потому что ваш инвентарь был заполнен, используйте <yellow>/skills claimitems <red>для их получения"
+  limit_reached: "<red>Достигнут лимит, осталось {time} секунд"
 menus:
   common:
     close: "Закрыть"

--- a/common/src/main/resources/messages/messages_th.yml
+++ b/common/src/main/resources/messages/messages_th.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: ปลดล็อคความสามารถของมานา
   mana_ability_level_up: ระดับความสามารถมานาเพิ่มขึ้น
   unclaimed_item: "<red>คุณมีสินค้าที่ไม่มีการอ้างสิทธิ์เนื่องจากสินค้าคงคลังของคุณเต็ม ใช้งาน <yellow>/skills claimitems <red>เพื่อเรียกร้องพวกเขา"
+  limit_reached: "<red>ถึงขีดจำกัดแล้ว เหลือเวลาอีก {time} วินาที"
 menus:
   common:
     close: "ปิด"

--- a/common/src/main/resources/messages/messages_tr.yml
+++ b/common/src/main/resources/messages/messages_tr.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Mana Yeteneği Kilidini Açma
   mana_ability_level_up: Mana Yeteneği Seviye Yükseltme
   unclaimed_item: "<red>Envanteriniz dolu olduğu için sahipsiz eşyalarınız var, onları sahiplenmek için <yellow>/skills claimitems <red>kullanın"
+  limit_reached: "<red>Sınır aşıldı, {time} saniye kaldı"
 menus:
   common:
     close: "Kapat"

--- a/common/src/main/resources/messages/messages_uk.yml
+++ b/common/src/main/resources/messages/messages_uk.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Mana Ability Unlock
   mana_ability_level_up: Mana Ability Level Up
   unclaimed_item: "<red>You have unclaimed items because your inventory was full, use <yellow>/skills claimitems <red>to claim them"
+  limit_reached: "<red>Limit reached, {time} seconds remaining"
 menus:
   common:
     close: "Close"

--- a/common/src/main/resources/messages/messages_vi.yml
+++ b/common/src/main/resources/messages/messages_vi.yml
@@ -533,6 +533,7 @@ leveler:
   mana_ability_unlock: Kĩ năng ma pháp
   mana_ability_level_up: Lên cắp Kĩ năng Ma pháp
   unclaimed_item: "<red>Bạn có vật phẩm chưa nhận do kho đồ đã đầy, dùng <yellow>/skills claimitems <red>để nhận"
+  limit_reached: "<red>Đã đạt giới hạn, còn lại {time} giây"
 menus:
   common:
     close: "Đóng"

--- a/common/src/main/resources/messages/messages_zh-CN.yml
+++ b/common/src/main/resources/messages/messages_zh-CN.yml
@@ -682,6 +682,7 @@ leveler:
   mana_ability_unlock: 解锁魔法能力
   mana_ability_level_up: 魔法能力等级提升
   unclaimed_item: "<red>因为背包已满, 部分无法存储在物品栏的物品已被转移至临时存储区. 请输入 <yellow>/skills claimitems <red>及时领取这些物品."
+  limit_reached: "<red>已达到限制，还剩 {time} 秒"
 menus:
   common:
     close: "关闭"

--- a/common/src/main/resources/messages/messages_zh-TW.yml
+++ b/common/src/main/resources/messages/messages_zh-TW.yml
@@ -566,6 +566,7 @@ leveler:
   mana_ability_unlock: 法力能力解鎖
   mana_ability_level_up: 法力能力等級提升
   unclaimed_item: "<red>由於庫存已滿，您有無人認領的物品，請使用 <yellow>/skills claimitems <red>領取它們"
+  limit_reached: "<red>已達到限制，剩下 {time} 秒"
 menus:
   common:
     close: "關閉"

--- a/common/src/main/resources/skills.yml
+++ b/common/src/main/resources/skills.yml
@@ -12,6 +12,10 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/foraging:
     abilities:
       - auraskills/lumberjack
@@ -25,6 +29,10 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/mining:
     abilities:
       - auraskills/lucky_miner
@@ -38,6 +46,10 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/fishing:
     abilities:
       - auraskills/lucky_catch
@@ -51,6 +63,10 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/excavation:
     abilities:
       - auraskills/bigger_scoop
@@ -64,6 +80,10 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/archery:
     abilities:
       - auraskills/retrieval
@@ -77,6 +97,10 @@ skills:
       max_level: 100
       spawner_multiplier: 1
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/defense:
     abilities:
       - auraskills/shielding
@@ -93,6 +117,10 @@ skills:
       min: 0
       allow_shield_blocking: false
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/fighting:
     abilities:
       - auraskills/parry
@@ -106,6 +134,10 @@ skills:
       max_level: 100
       spawner_multiplier: 1
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/agility:
     abilities:
       - auraskills/light_fall
@@ -118,6 +150,10 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/alchemy:
     abilities:
       - auraskills/alchemist
@@ -131,6 +167,10 @@ skills:
       check_cancelled: true
       check_multiplier_permissions: true
       ignore_custom_potions: false
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
   auraskills/enchanting:
     abilities:
       - auraskills/xp_convert
@@ -143,4 +183,8 @@ skills:
       max_level: 100
       check_cancelled: true
       check_multiplier_permissions: true
-file_version: 1
+      limiter:
+        enabled: true
+        cap: -1
+        time: -1
+file_version: 2


### PR DESCRIPTION
Disabled by default, can be configured to use per skill or an overall limit. When set to per skill each can be enabled/disabled and have it's own or a global cap/time.